### PR TITLE
Make server URL configurable at build time

### DIFF
--- a/doc/CustomizingOmaha.md
+++ b/doc/CustomizingOmaha.md
@@ -26,7 +26,7 @@ The following items **MUST** be changed before releasing a fork of Omaha.  Prefe
 
   * **`omaha\base\const_addresses.h`**
 
-> If necessary, modify the URLs that will be used for performing update checks and returning results to match your update server's implementation.
+> URLs can be defined as Environment variable (the full list can be found in the main scons build script). If necessary, modify the URLs that will be used for performing update checks and returning results to match your update server's implementation.
 
   * **`omaha\goopdate\omaha3_idl.idl`**
 

--- a/omaha/base/const_addresses.h
+++ b/omaha/base/const_addresses.h
@@ -58,17 +58,17 @@ const TCHAR* const kGoopdateServer = _T("tools.") COMPANY_DOMAIN;
 // The channel for update checks is secured by using CUP to sign the messages.
 // It does not depend solely on https security in any case.
 const TCHAR* const kUrlUpdateCheck =
-    _T("https://update.") COMPANY_DOMAIN_BASE _T("apis.com/service/update2");
+    _T("https://") SERVICE_DOMAIN _T("/service/update2");
 
 // Pings.
 const TCHAR* const kUrlPing =
-  _T("https://update.") COMPANY_DOMAIN_BASE _T("apis.com/service/update2");
+    _T("https://") SERVICE_DOMAIN _T("/service/update2");
 
 // The urls below never fall back to http.
 //
 // Crash reports.
 const TCHAR* const kUrlCrashReport =
-    _T("https://clients2.") COMPANY_DOMAIN _T("/cr/report");
+    _T("https://") SERVICE_DOMAIN _T("/service/crash_report/");
 
 // More information url.
 // Must allow query parameters to be appended to it.
@@ -81,7 +81,7 @@ const TCHAR* const kUrlCodeRedCheck =
 
 // Usage stats url.
 const TCHAR* const kUrlUsageStatsReport =
-    _T("https://clients5.") COMPANY_DOMAIN _T("/tbproxy/usagestats");
+    _T("https://") SERVICE_DOMAIN  _T("/tbproxy/usagestats");
 
 }  // namespace omaha
 

--- a/omaha/base/const_addresses.h
+++ b/omaha/base/const_addresses.h
@@ -29,11 +29,11 @@ namespace omaha {
 // Static string that gives the main Google website address
 // TODO(omaha): Rename this as a connection-check URL. Name should be in caps
 // and not include "Google".
-#define kGoogleHttpServer _T("www.") COMPANY_DOMAIN
+#define kGoogleHttpServer MAIN_COMPANY_WEBSITE
 
 // Static string used as an identity for the "Omaha" Google domain.
 // TODO(omaha): Rename this as a plug-in domain.
-const TCHAR* const kGoopdateServer = _T("tools.") COMPANY_DOMAIN;
+const TCHAR* const kGoopdateServer = PLUGIN_DOMAIN;
 
 // HTTP protocol prefix
 #define kProtoSuffix              _T("://")
@@ -57,31 +57,25 @@ const TCHAR* const kGoopdateServer = _T("tools.") COMPANY_DOMAIN;
 // Update checks.
 // The channel for update checks is secured by using CUP to sign the messages.
 // It does not depend solely on https security in any case.
-const TCHAR* const kUrlUpdateCheck =
-    _T("https://") SERVICE_DOMAIN _T("/service/update2");
+const TCHAR* const kUrlUpdateCheck = UPDATE_CHECK_URL;
 
 // Pings.
-const TCHAR* const kUrlPing =
-    _T("https://") SERVICE_DOMAIN _T("/service/update2");
+const TCHAR* const kUrlPing = PING_URL;
 
 // The urls below never fall back to http.
 //
 // Crash reports.
-const TCHAR* const kUrlCrashReport =
-    _T("https://") SERVICE_DOMAIN _T("/service/crash_report/");
+const TCHAR* const kUrlCrashReport = CRASH_REPORT_URL;
 
 // More information url.
 // Must allow query parameters to be appended to it.
-const TCHAR* const kUrlMoreInfo =
-    _T("https://www.") COMPANY_DOMAIN _T("/support/installer/?");
+const TCHAR* const kUrlMoreInfo = MORE_INFO_URL;
 
 // Code Red check url.
-const TCHAR* const kUrlCodeRedCheck =
-    _T("https://clients2.") COMPANY_DOMAIN _T("/service/check2");
+const TCHAR* const kUrlCodeRedCheck = CODE_RED_CHECK_URL;
 
 // Usage stats url.
-const TCHAR* const kUrlUsageStatsReport =
-    _T("https://") SERVICE_DOMAIN  _T("/tbproxy/usagestats");
+const TCHAR* const kUrlUsageStatsReport = USAGE_STATS_REPORT_URL;
 
 }  // namespace omaha
 

--- a/omaha/base/constants.h
+++ b/omaha/base/constants.h
@@ -66,6 +66,10 @@ const TCHAR* const kShortCompanyName = SHORT_COMPANY_NAME;
 // COMPANY_DOMAIN_ANSI = "google.com"
 #define COMPANY_DOMAIN _T(COMPANY_DOMAIN_ANSI)
 
+// Service domain name. Used for communication with update server.
+// SERVICE_DOMAIN_ANSI = "update.googleapis.com"
+#define SERVICE_DOMAIN _T(SERVICE_DOMAIN_ANSI)
+
 // Company's internal network DNS domain. Used for detecting internal users.
 // If the internal network uses a different domain than the public-facing
 // COMPANY_DOMAIN, this will need to be changed.

--- a/omaha/base/constants.h
+++ b/omaha/base/constants.h
@@ -66,6 +66,62 @@ const TCHAR* const kShortCompanyName = SHORT_COMPANY_NAME;
 // COMPANY_DOMAIN_ANSI = "google.com"
 #define COMPANY_DOMAIN _T(COMPANY_DOMAIN_ANSI)
 
+// Static string that gives the main Google website address
+#ifdef MAIN_COMPANY_WEBSITE_ANSI
+#define MAIN_COMPANY_WEBSITE _T(MAIN_COMPANY_WEBSITE_ANSI)
+#else
+#define MAIN_COMPANY_WEBSITE _T("www.") COMPANY_DOMAIN
+#endif
+
+// Static string used as an identity for the "Omaha" plug-in domain.
+#ifdef PLUGIN_DOMAIN_ANSI
+#define PLUGIN_DOMAIN _T(PLUGIN_DOMAIN_ANSI)
+#else
+#define PLUGIN_DOMAIN _T("tools.") COMPANY_DOMAIN
+#endif
+
+// Update checks.
+#ifdef UPDATE_CHECK_URL_ANSI
+#define UPDATE_CHECK_URL _T(UPDATE_CHECK_URL_ANSI)
+#else
+#define UPDATE_CHECK_URL _T("https://update.") COMPANY_DOMAIN_BASE _T("apis.com/service/update2")
+#endif
+
+// Pings.
+#ifdef PING_URL_ANSI
+#define PING_URL _T(PING_URL_ANSI)
+#else
+#define PING_URL _T("https://update.") COMPANY_DOMAIN_BASE _T("apis.com/service/update2")
+#endif
+
+// Crash reports.
+#ifdef CRASH_REPORT_URL_ANSI
+#define CRASH_REPORT_URL _T(CRASH_REPORT_URL_ANSI)
+#else
+#define CRASH_REPORT_URL _T("https://clients2.") COMPANY_DOMAIN _T("/cr/report")
+#endif
+
+// More information url.
+#ifdef MORE_INFO_URL_ANSI
+#define MORE_INFO_URL _T(MORE_INFO_URL_ANSI)
+#else
+#define MORE_INFO_URL _T("https://www.") COMPANY_DOMAIN _T("/support/installer/?")
+#endif
+
+// Code Red check url.
+#ifdef CODE_RED_CHECK_URL_ANSI
+#define CODE_RED_CHECK_URL _T(CODE_RED_CHECK_URL_ANSI)
+#else
+#define CODE_RED_CHECK_URL _T("https://clients2.") COMPANY_DOMAIN _T("/service/check2")
+#endif
+
+//  Usage stats url.
+#ifdef USAGE_STATS_REPORT_URL_ANSI
+#define USAGE_STATS_REPORT_URL _T(USAGE_STATS_REPORT_URL_ANSI)
+#else
+#define USAGE_STATS_REPORT_URL _T("https://") SERVICE_DOMAIN  _T("/tbproxy/usagestats")
+#endif
+
 // Service domain name. Used for communication with update server.
 // SERVICE_DOMAIN_ANSI = "update.googleapis.com"
 #define SERVICE_DOMAIN _T(SERVICE_DOMAIN_ANSI)

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -70,7 +70,9 @@ _SHORT_COMPANY_NAME = 'OmahaCompanyName'
 _PRODUCT_NAME = 'Update'
 _COMPANY_DOMAIN_BASE = 'google'
 _COMPANY_DOMAIN = _COMPANY_DOMAIN_BASE + '.com'
+_SERVICE_DOMAIN = os.getenv('SERVICE_DOMAIN', "update.googleapis.com")
 _MAIN_EXE_BASE_NAME = 'GoogleUpdate'
+
 # TODO(omaha): Use this throughout the build files where goopdate and
 # goopdateres are referenced.
 _MAIN_DLL_BASE_NAME = 'goopdate'
@@ -561,6 +563,7 @@ win_env.AppendUnique(
         'PRODUCT_NAME_ANSI=\\"%s\\"' % _PRODUCT_NAME,
         'COMPANY_DOMAIN_BASE_ANSI=\\"%s\\"' % _COMPANY_DOMAIN_BASE,
         'COMPANY_DOMAIN_ANSI=\\"%s\\"' % _COMPANY_DOMAIN,
+        'SERVICE_DOMAIN_ANSI=\\"%s\\"' % _SERVICE_DOMAIN,
         'OMAHA_APP_NAME_ANSI=\\"%s %s\\"' % (
             _SHORT_COMPANY_NAME, _PRODUCT_NAME),
         'MAIN_EXE_BASE_NAME_ANSI=\\"%s\\"' % _MAIN_EXE_BASE_NAME,

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -70,8 +70,19 @@ _SHORT_COMPANY_NAME = 'OmahaCompanyName'
 _PRODUCT_NAME = 'Update'
 _COMPANY_DOMAIN_BASE = 'google'
 _COMPANY_DOMAIN = _COMPANY_DOMAIN_BASE + '.com'
-_SERVICE_DOMAIN = os.getenv('SERVICE_DOMAIN', "update.googleapis.com")
 _MAIN_EXE_BASE_NAME = 'GoogleUpdate'
+
+# Optionals defines.
+# The following values can be used to override Omaha's default URLs used
+# to communicate with the various services endpoint.
+_MAIN_COMPANY_WEBSITE = os.getenv('OMAHA_MAIN_COMPANY_WEBSITE')
+_PLUGIN_DOMAIN = os.getenv('OMAHA_PLUGIN_DOMAIN')
+_UPDATE_CHECK_URL = os.getenv('OMAHA_UPDATE_CHECK_URL')
+_PING_URL = os.getenv('OMAHA_PING_URL')
+_CRASH_REPORT_URL = os.getenv('OMAHA_CRASH_REPORT_URL')
+_MORE_INFO_URL = os.getenv('OMAHA_MORE_INFO_URL')
+_CODE_RED_CHECK_URL = os.getenv('OMAHA_CODE_RED_CHECK_URL')
+_USAGE_STATS_REPORT_URL = os.getenv('OMAHA_USAGE_STATS_REPORT_URL')
 
 # TODO(omaha): Use this throughout the build files where goopdate and
 # goopdateres are referenced.
@@ -563,7 +574,6 @@ win_env.AppendUnique(
         'PRODUCT_NAME_ANSI=\\"%s\\"' % _PRODUCT_NAME,
         'COMPANY_DOMAIN_BASE_ANSI=\\"%s\\"' % _COMPANY_DOMAIN_BASE,
         'COMPANY_DOMAIN_ANSI=\\"%s\\"' % _COMPANY_DOMAIN,
-        'SERVICE_DOMAIN_ANSI=\\"%s\\"' % _SERVICE_DOMAIN,
         'OMAHA_APP_NAME_ANSI=\\"%s %s\\"' % (
             _SHORT_COMPANY_NAME, _PRODUCT_NAME),
         'MAIN_EXE_BASE_NAME_ANSI=\\"%s\\"' % _MAIN_EXE_BASE_NAME,
@@ -632,6 +642,38 @@ win_env.AppendUnique(
             _OMAHA_COPYRIGHT_STRING_ENGLISH),
         ],
 )
+if _MAIN_COMPANY_WEBSITE:
+    win_env.AppendUnique(CPPDEFINES = [
+        'MAIN_COMPANY_WEBSITE_ANSI=\\"%s\\"' % _MAIN_COMPANY_WEBSITE,
+    ])
+if _PLUGIN_DOMAIN:
+    win_env.AppendUnique(CPPDEFINES = [
+        'PLUGIN_DOMAIN_ANSI=\\"%s\\"' % _PLUGIN_DOMAIN,
+    ])
+if _UPDATE_CHECK_URL:
+    win_env.AppendUnique(CPPDEFINES = [
+        'UPDATE_CHECK_URL_ANSI=\\"%s\\"' % _UPDATE_CHECK_URL,
+    ])
+if _PING_URL:
+    win_env.AppendUnique(CPPDEFINES = [
+        'PING_URL=\\"%s\\"' % _PING_URL,
+    ])
+if _CRASH_REPORT_URL:
+    win_env.AppendUnique(CPPDEFINES = [
+        'CRASH_REPORT_URL=\\"%s\\"' % _CRASH_REPORT_URL,
+    ])
+if _MORE_INFO_URL:
+    win_env.AppendUnique(CPPDEFINES = [
+        'MORE_INFO_URL=\\"%s\\"' % _MORE_INFO_URL,
+    ])
+if _CODE_RED_CHECK_URL:
+    win_env.AppendUnique(CPPDEFINES = [
+        'CODE_RED_CHECK_URL=\\"%s\\"' % _CODE_RED_CHECK_URL,
+    ])
+if _USAGE_STATS_REPORT_URL:
+    win_env.AppendUnique(CPPDEFINES = [
+        'USAGE_STATS_REPORT_URL=\\"%s\\"' % _USAGE_STATS_REPORT_URL,
+    ])
 
 if _is_google_update_build:
     win_env.AppendUnique(CPPPATH = [


### PR DESCRIPTION
- add scons CPPDEFINE reading SERVICE_DOMAIN env variable
- define is as  constant in base/constants.h
- use it const_addresses.h for the various URL endpoints
- adapt URL endpoints for crystalnix/omaha-server