### PR TITLE
 Extract environment overrides from project (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ BRANCH_OWNERS
 omaha/common/omaha_customization_proxy_clsid.h
 omaha/proxy_clsids.txt
 omaha/*.idb
-omaha/env.bat
 omaha/scons-out/**
 
 # Ignore compiled Python files.

--- a/omaha/env.bat.sample
+++ b/omaha/env.bat.sample
@@ -1,9 +1,0 @@
-set OMAHA_BASE_URL=https://updates.google.com
-set OMAHA_MAIN_COMPANY_WEBSITE=http://www.google.com
-set OMAHA_PLUGIN_DOMAIN=updates.google.com
-set OMAHA_UPDATE_CHECK_URL=%OMAHA_BASE_URL%/service/update2
-set OMAHA_PING_URL=%OMAHA_BASE_URL%/service/update2
-set OMAHA_CRASH_REPORT_URL=%OMAHA_BASE_URL%/cr/report
-set OMAHA_MORE_INFO_URL=http://www.google.com/updates
-set OMAHA_CODE_RED_CHECK_URL=%OMAHA_BASE_URL%/service/check2
-set OMAHA_USAGE_STATS_REPORT_URL=%OMAHA_BASE_URL%/tbproxy/usagestats

--- a/omaha/hammer.bat
+++ b/omaha/hammer.bat
@@ -1,6 +1,5 @@
 @echo off
 
-call env.bat
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat"
 
 :: Hammer does not need this variable but the unit


### PR DESCRIPTION
We should not declare environment variables from the project but rather in the launchers themselves